### PR TITLE
Update to sourceror 1.12

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.1-otp-25
-erlang 25.1.1
+erlang 25.2.3
+elixir 1.14.3-otp-25

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Changeling.MixProject do
   defp deps do
     [
       {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:sourceror, "~> 0.11.1"}
+      {:sourceror, "~> 0.12"}
     ]
   end
 end


### PR DESCRIPTION
Sourceror removed the concept of an ended zipper from Zipper: https://github.com/doorgan/sourceror/pull/68

Update to handle `nil` return from `Zipper.next()`.